### PR TITLE
Add Growing Window Rolling Functions

### DIFF
--- a/market_analyzer.py
+++ b/market_analyzer.py
@@ -5,7 +5,7 @@ https://claude.ai/chat/e57d8498-85ed-478a-9aa4-a5dcba070116
 
 import pandas as pd
 import numpy as np
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from arch import arch_model
 import warnings
 from typing import Tuple, List, Dict, Optional, Union, Any
@@ -2318,3 +2318,114 @@ class MarketAnalyzer:
         }
         
         return figures
+
+
+def rolling_growing_window(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    func: Callable,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """
+    Apply a rolling window function with growing window size for initial periods.
+    
+    Parameters
+    ----------
+    data : pd.Series or np.ndarray
+        Input data to compute the rolling function on
+    window : int
+        Maximum size of the rolling window
+    func : Callable
+        Function to apply to each window (e.g., np.mean, np.std)
+    min_periods : int, optional
+        Minimum number of observations required for calculation.
+        If None, defaults to 1.
+        
+    Returns
+    -------
+    np.ndarray
+        Array of same length as input with rolling calculation results
+        
+    Examples
+    --------
+    >>> data = pd.Series([1, 2, 3, 4, 5])
+    >>> rolling_growing_window(data, window=3, func=np.mean)
+    array([1., 1.5, 2., 3., 4.])
+    
+    >>> # Custom function example
+    >>> def weighted_mean(x):
+    ...     weights = np.arange(1, len(x) + 1)
+    ...     return np.average(x, weights=weights)
+    >>> rolling_growing_window(data, window=3, func=weighted_mean)
+    
+    Notes
+    -----
+    The function handles the initial periods (i < window) by using all available
+    data up to that point, creating a growing window effect. After reaching the
+    window size, it uses a standard rolling window.
+    """
+    # Convert input to numpy array if it's a Series
+    if isinstance(data, pd.Series):
+        data = data.values
+    
+    # Set default min_periods
+    if min_periods is None:
+        min_periods = 1
+    
+    # Initialize output array
+    result = np.zeros(len(data))
+    
+    # Handle each position
+    for i in range(len(data)):
+        if i < window:
+            # Growing window phase
+            if i + 1 >= min_periods:
+                result[i] = func(data[:i+1])
+            else:
+                result[i] = np.nan
+        else:
+            # Standard rolling window
+            result[i] = func(data[i-window+1:i+1])
+    
+    return result
+
+# Example specialized functions using the growing window
+def growing_mean(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """Calculate rolling mean with growing initial window."""
+    return rolling_growing_window(data, window, np.mean, min_periods)
+
+def growing_std(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """Calculate rolling standard deviation with growing initial window."""
+    return rolling_growing_window(data, window, np.std, min_periods)
+
+def growing_sum(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """Calculate rolling sum with growing initial window."""
+    return rolling_growing_window(data, window, np.sum, min_periods)
+
+def growing_max(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """Calculate rolling maximum with growing initial window."""
+    return rolling_growing_window(data, window, np.max, min_periods)
+
+def growing_min(
+    data: Union[pd.Series, np.ndarray],
+    window: int,
+    min_periods: Optional[int] = None
+) -> np.ndarray:
+    """Calculate rolling minimum with growing initial window."""
+    return rolling_growing_window(data, window, np.min, min_periods)        

--- a/test_market_analyzer.py
+++ b/test_market_analyzer.py
@@ -13,7 +13,14 @@ from market_analyzer import (MarketAnalyzer,
                              RiskAnalyzer, 
                              VolumePatternType, 
                              VolumePattern,
-                             RegimeAnalyzer)
+                             RegimeAnalyzer,
+                             rolling_growing_window,
+                             growing_max,
+                             growing_mean,
+                             growing_min,
+                             growing_std,
+                             growing_sum)
+from numpy.testing import assert_array_almost_equal
 from typing import Dict, Any
 
 @pytest.fixture
@@ -1905,3 +1912,108 @@ class TestRiskAnalyzer:
         # Invalid time horizon
         with pytest.raises(ValueError):
             risk_analyzer.calculate_var(time_horizon=-1)        
+
+
+class TestGrowingWindowRolling:
+    def test_growing_window_basic(self):
+        """Test basic functionality with simple mean calculation"""
+        data = np.array([1, 2, 3, 4, 5])
+        result = rolling_growing_window(data, window=3, func=np.mean)
+        expected = np.array([1., 1.5, 2., 3., 4.])
+        assert_array_almost_equal(result, expected)
+
+    def test_growing_window_pandas(self):
+        """Test with pandas Series input"""
+        data = pd.Series([1, 2, 3, 4, 5])
+        result = rolling_growing_window(data, window=3, func=np.mean)
+        expected = np.array([1., 1.5, 2., 3., 4.])
+        assert_array_almost_equal(result, expected)
+
+    def test_growing_window_min_periods(self):
+        """Test minimum periods requirement"""
+        data = np.array([1, 2, 3, 4, 5])
+        result = rolling_growing_window(data, window=3, func=np.mean, min_periods=2)
+        expected = np.array([np.nan, 1.5, 2., 3., 4.])
+        assert_array_almost_equal(result, expected)
+
+    def test_growing_std(self):
+        """Test growing window standard deviation"""
+        data = np.array([1, 1, 1, 2, 2])
+        result = growing_std(data, window=3)
+        # First value should be 0 (no std for single value)
+        # Second value should be 0 (std of [1,1])
+        # Third value should be 0 (std of [1,1,1])
+        # Fourth and fifth values should have non-zero std
+        assert result[0] == 0
+        assert result[1] == 0
+        assert result[2] == 0
+        assert result[3] > 0
+        assert result[4] > 0
+
+    def test_custom_function(self):
+        """Test with a custom window function"""
+        def weighted_mean(x):
+            weights = np.arange(1, len(x) + 1)
+            return np.average(x, weights=weights)
+        
+        data = np.array([1, 2, 3, 4, 5])
+        result = rolling_growing_window(data, window=3, func=weighted_mean)
+        # Manual calculation for verification
+        expected = np.array([
+            1.0,  # single value
+            1.666666667,  # weighted mean of [1,2]
+            2.333333333,  # weighted mean of [1,2,3]
+            3.333333333,  # weighted mean of [2,3,4]
+            4.333333333   # weighted mean of [3,4,5]
+        ])
+        assert_array_almost_equal(result, expected, decimal=5)
+
+    def test_edge_cases(self):
+        """Test edge cases"""
+        # Empty array
+        data = np.array([])
+        result = rolling_growing_window(data, window=3, func=np.mean)
+        assert len(result) == 0
+        
+        # Window size larger than data
+        data = np.array([1, 2, 3])
+        result = rolling_growing_window(data, window=5, func=np.mean)
+        expected = np.array([1., 1.5, 2.])
+        assert_array_almost_equal(result, expected)
+        
+        # Window size of 1
+        data = np.array([1, 2, 3])
+        result = rolling_growing_window(data, window=1, func=np.mean)
+        assert_array_almost_equal(result, data)
+
+    def test_specialized_functions(self):
+        """Test all specialized growing window functions"""
+        data = np.array([1, 2, 3, 4, 5])
+        
+        # Test growing_mean
+        mean_result = growing_mean(data, window=3)
+        assert_array_almost_equal(
+            mean_result,
+            np.array([1., 1.5, 2., 3., 4.])
+        )
+        
+        # Test growing_sum
+        sum_result = growing_sum(data, window=3)
+        assert_array_almost_equal(
+            sum_result,
+            np.array([1., 3., 6., 9., 12.])
+        )
+        
+        # Test growing_max
+        max_result = growing_max(data, window=3)
+        assert_array_almost_equal(
+            max_result,
+            np.array([1., 2., 3., 4., 5.])
+        )
+        
+        # Test growing_min
+        min_result = growing_min(data, window=3)
+        assert_array_almost_equal(
+            min_result,
+            np.array([1., 1., 1., 2., 3.])
+        )


### PR DESCRIPTION
# Add Growing Window Rolling Functions

## Overview
This PR introduces a flexible utility for performing rolling window calculations that handles initial periods using a growing window approach instead of producing NaN values. This is particularly useful for financial analysis where we want meaningful calculations from the start of our time series.

## Key Features
1. **Core Functionality**
   - Generic `rolling_growing_window` function that supports arbitrary window functions
   - Handles both numpy arrays and pandas Series inputs
   - Configurable minimum periods requirement
   - No NaN values at the start of the series (unless explicitly requested via min_periods)

2. **Convenience Functions**
   - `growing_mean`: Rolling mean with growing window
   - `growing_std`: Rolling standard deviation with growing window
   - `growing_sum`: Rolling sum with growing window
   - `growing_max`: Rolling maximum with growing window
   - `growing_min`: Rolling minimum with growing window

## Use Cases
This functionality is particularly useful for:
- Technical indicators that need rolling calculations
- Regime detection algorithms
- Risk metrics that require rolling windows
- Any analysis where initial NaN values are problematic

## Example Usage
```python
# Basic usage
data = pd.Series([1, 2, 3, 4, 5])
result = growing_mean(data, window=3)
# result: array([1., 1.5, 2., 3., 4.])

# Custom function
def weighted_mean(x):
    weights = np.arange(1, len(x) + 1)
    return np.average(x, weights=weights)
result = rolling_growing_window(data, window=3, func=weighted_mean)